### PR TITLE
solve <Undefined variable logged_in> warning/error in pubic.volt layout

### DIFF
--- a/app/views/layouts/public.volt
+++ b/app/views/layouts/public.volt
@@ -26,7 +26,7 @@
           </ul>
 
           <ul class="nav pull-right">
-            {%- if logged_in %}
+            {%- if not(logged_in is empty) %}
             <li>{{ link_to('users', 'Users Panel') }}</li>
             <li>{{ link_to('session/logout', 'Logout') }}</li>
             {% else %}


### PR DESCRIPTION
better condition to solve

Notice: Undefined variable: logged_in in /path/to/cache/filevolt.php on line 18

in about/ and session/login routes

![screen shot 2015-01-24 at 13 21 43](https://cloud.githubusercontent.com/assets/3394457/5887584/fd49933e-a3d0-11e4-8616-e1c0ce4623d2.png)
