### PR TITLE
Security issue fixed

### DIFF
--- a/app/library/Acl/Acl.php
+++ b/app/library/Acl/Acl.php
@@ -75,6 +75,7 @@ class Acl extends Component
      */
     public function isPrivate($controllerName)
     {
+        $controllerName = strtolower($controllerName);
         return isset($this->privateResources[$controllerName]);
     }
 


### PR DESCRIPTION
Without this change, anyone can access a private module changing the first letter to uppercase obtaining access on a non authorized page.