### PR TITLE
clear form values for password and csrf

### DIFF
--- a/app/forms/LoginForm.php
+++ b/app/forms/LoginForm.php
@@ -41,6 +41,8 @@ class LoginForm extends Form
             'message' => 'The password is required'
         )));
 
+        $password->clear();
+
         $this->add($password);
 
         // Remember
@@ -59,6 +61,8 @@ class LoginForm extends Form
             'value' => $this->security->getSessionToken(),
             'message' => 'CSRF validation failed'
         )));
+
+        $csrf->clear();
 
         $this->add($csrf);
 


### PR DESCRIPTION
Security fix, if a wrong email / password is entered the form returns filled with the entered content:
* the entered password is returned in plain HTML
* the csrf field is filled with the old value instead of the newly generated token.