### PR TITLE
FIX crash when updating password successfully

### DIFF
--- a/app/controllers/UsersController.php
+++ b/app/controllers/UsersController.php
@@ -192,7 +192,8 @@ class UsersController extends ControllerBase
 
                     $this->flash->success('Your password was successfully changed');
 
-                    Tag::resetInput();
+                    Tag::setDefault('password', '');
+                    Tag::setDefault('confirmPassword', '');
                 }
             }
         }


### PR DESCRIPTION
Tag::resetInput seems has bug in Phalcon 2.1. Set input to empty value as solution