### PR TITLE
Select between Direct SMTP or Amazon SES based on mail configuration

### DIFF
--- a/app/library/Mail/Mail.php
+++ b/app/library/Mail/Mail.php
@@ -16,8 +16,6 @@ class Mail extends Component
 
     protected $amazonSes;
 
-    protected $directSmtp = false;
-
     /**
      * Send a raw e-mail via AmazonSES
      *
@@ -101,7 +99,7 @@ class Mail extends Component
             ))
             ->setBody($template, 'text/html');
 
-        if ($this->directSmtp) {
+        if (isset($mailSettings) && isset($mailSettings->smtp)) {
 
             if (!$this->transport) {
                 $this->transport = Smtp::newInstance(


### PR DESCRIPTION
Currently Amazon SES selection is hardcoded by  protected $directSmtp = false;  It will  be nice to make the choice from the config.php file. In this proposed change, I am checking for the presence of $config->mail->smtp to use direct SMTP. Otherwise use Amazon SES.