### PR TITLE
Makes email usage optional.

### DIFF
--- a/app/config/config.php
+++ b/app/config/config.php
@@ -44,5 +44,7 @@ return new Config([
         'date'     => 'D j H:i:s',
         'logLevel' => Logger::DEBUG,
         'filename' => 'application.log',
-    ]
+    ],
+    // Set to false to disable sending emails (for use in test environment)
+    'useMail' => true
 ]);

--- a/app/controllers/SessionController.php
+++ b/app/controllers/SessionController.php
@@ -105,28 +105,34 @@ class SessionController extends ControllerBase
         $form = new ForgotPasswordForm();
 
         if ($this->request->isPost()) {
+            
+            // Send emails only is config value is set to true
+            if ($this->getDI()->get('config')->useMail) {
 
-            if ($form->isValid($this->request->getPost()) == false) {
-                foreach ($form->getMessages() as $message) {
-                    $this->flash->error($message);
-                }
-            } else {
-
-                $user = Users::findFirstByEmail($this->request->getPost('email'));
-                if (!$user) {
-                    $this->flash->success('There is no account associated to this email');
+                if ($form->isValid($this->request->getPost()) == false) {
+                    foreach ($form->getMessages() as $message) {
+                        $this->flash->error($message);
+                    }
                 } else {
 
-                    $resetPassword = new ResetPasswords();
-                    $resetPassword->usersId = $user->id;
-                    if ($resetPassword->save()) {
-                        $this->flash->success('Success! Please check your messages for an email reset password');
+                    $user = Users::findFirstByEmail($this->request->getPost('email'));
+                    if (!$user) {
+                        $this->flash->success('There is no account associated to this email');
                     } else {
-                        foreach ($resetPassword->getMessages() as $message) {
-                            $this->flash->error($message);
+
+                        $resetPassword = new ResetPasswords();
+                        $resetPassword->usersId = $user->id;
+                        if ($resetPassword->save()) {
+                            $this->flash->success('Success! Please check your messages for an email reset password');
+                        } else {
+                            foreach ($resetPassword->getMessages() as $message) {
+                                $this->flash->error($message);
+                            }
                         }
                     }
                 }
+            } else {
+                $this->flash->warning('Emails are currently disabled. Change config key "useMail" to true to enable emails.');
             }
         }
 

--- a/app/models/Users.php
+++ b/app/models/Users.php
@@ -89,8 +89,13 @@ class Users extends Model
         }
 
         // The account must be confirmed via e-mail
-        $this->active = 'N';
-
+        // Only require this if emails are turned on in the config, otherwise account is automatically active
+        if ($this->getDI()->get('config')->useMail) {
+            $this->active = 'N';
+        } else {
+            $this->active = 'Y';
+        }
+        
         // The account is not suspended by default
         $this->suspended = 'N';
 
@@ -103,16 +108,20 @@ class Users extends Model
      */
     public function afterSave()
     {
-        if ($this->active == 'N') {
+        // Only send the confirmation email if emails are turned on in the config
+        if ($this->getDI()->get('config')->useMail) {
 
-            $emailConfirmation = new EmailConfirmations();
+            if ($this->active == 'N') {
 
-            $emailConfirmation->usersId = $this->id;
+                $emailConfirmation = new EmailConfirmations();
 
-            if ($emailConfirmation->save()) {
-                $this->getDI()
-                    ->getFlash()
-                    ->notice('A confirmation mail has been sent to ' . $this->email);
+                $emailConfirmation->usersId = $this->id;
+
+                if ($emailConfirmation->save()) {
+                    $this->getDI()
+                        ->getFlash()
+                        ->notice('A confirmation mail has been sent to ' . $this->email);
+                }
             }
         }
     }


### PR DESCRIPTION
Closes issue #44. The addition of a boolean to the config with the
key 'useMail' (default is true). This is checked when requiring email
verification of accounts and sending emails for password resets. If
false, no emails are sent; if true normal behaviour is followed.

Allows for easy use in a test environment where emails cannot be sent.