### PR TITLE
Added dev config to services.php and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ cache/volt/*.php
 /vendor
 cache/metaData/*.php
 data.txt
+app/config/config.dev.php

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Then you'll need to create the database and initialize schema:
     echo 'CREATE DATABASE vokuro' | mysql -u root
     cat schemas/vokuro.sql | mysql -u root vokuro
 
+Also you can override application config by creating app/config/config.dev.php (already gitignored).
+
 Installing Dependencies via Composer
 ------------------------------------
 Vökuró's dependencies must be installed using Composer. Install composer in a common location or in your project:

--- a/app/config/services.php
+++ b/app/config/services.php
@@ -18,7 +18,14 @@ use Vokuro\Mail\Mail;
  * Register the global configuration as config
  */
 $di->setShared('config', function () {
-    return include APP_PATH . "/config/config.php";
+    $config = include APP_PATH . '/config/config.php';
+    
+    if (is_readable(APP_PATH . '/config/config.dev.php')) {
+        $override = include APP_PATH . '/config/config.dev.php';
+        $config->merge($override);
+    }
+    
+    return $config;
 });
 
 /**


### PR DESCRIPTION
Following the same approach as the Invo tutorial.
A dev config file (app/config/config.dev.php) has been added to
the .gitignore. A check is done to see if this file is readable
when loading the configuration, if it is then this config is merged
with app/config/config.php.