### PR TITLE
fixed double slash in error path Acl

### DIFF
--- a/app/library/Acl/Acl.php
+++ b/app/library/Acl/Acl.php
@@ -221,7 +221,7 @@ class Acl extends Component
     protected function getFilePath()
     {
         if (!isset($this->filePath)) {
-            $this->filePath = rtrim($this->config->application->cacheDir, '\\/') . '/acl/data.txt';
+            $this->filePath = ltrim($this->config->application->cacheDir, '\\/') . '/acl/data.txt';
         }
 
         return $this->filePath;

--- a/app/library/Acl/Acl.php
+++ b/app/library/Acl/Acl.php
@@ -221,7 +221,7 @@ class Acl extends Component
     protected function getFilePath()
     {
         if (!isset($this->filePath)) {
-            $this->filePath = $this->config->application->cacheDir . 'acl/data.txt';
+            $this->filePath = rtrim($this->config->application->cacheDir, '\\/') . '/acl/data.txt';
         }
 
         return $this->filePath;

--- a/app/library/Acl/Acl.php
+++ b/app/library/Acl/Acl.php
@@ -221,7 +221,7 @@ class Acl extends Component
     protected function getFilePath()
     {
         if (!isset($this->filePath)) {
-            $this->filePath = ltrim($this->config->application->cacheDir, '\\/') . '/acl/data.txt';
+            $this->filePath = rtrim($this->config->application->cacheDir, '\\/') . '/acl/data.txt';
         }
 
         return $this->filePath;

--- a/app/library/Acl/Acl.php
+++ b/app/library/Acl/Acl.php
@@ -221,7 +221,7 @@ class Acl extends Component
     protected function getFilePath()
     {
         if (!isset($this->filePath)) {
-            $this->filePath = $this->config->application->cacheDir . '/acl/data.txt';
+            $this->filePath = $this->config->application->cacheDir . 'acl/data.txt';
         }
 
         return $this->filePath;
@@ -229,7 +229,7 @@ class Acl extends Component
 
     /**
      * Adds an array of private resources to the ACL object.
-     * 
+     *
      * @param array $resources
      */
     public function addPrivateResources(array $resources) {


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
fixed double slash in path like `/cache//acl/data.txt`

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
