### PR TITLE
added link to user panel and logout on about page

### DIFF
--- a/app/controllers/AboutController.php
+++ b/app/controllers/AboutController.php
@@ -12,6 +12,7 @@ class AboutController extends ControllerBase
      */
     public function indexAction()
     {
+        $this->view->setVar('logged_in', is_array($this->auth->getIdentity()));
         $this->view->setTemplateBefore('public');
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: -

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
After log in user can't see link to `users panel` and `log out`, but can see `log in` 

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md