### PR TITLE
Fixed table </tbody> tag and standarized tag use in Users and Profiles (frontend)

### DIFF
--- a/app/views/profiles/search.volt
+++ b/app/views/profiles/search.volt
@@ -19,8 +19,8 @@
             <th>Active?</th>
         </tr>
     </thead>
-{% endif %}
     <tbody>
+{% endif %}
         <tr>
             <td>{{ profile.id }}</td>
             <td>{{ profile.name }}</td>
@@ -28,9 +28,9 @@
             <td width="12%">{{ link_to("profiles/edit/" ~ profile.id, '<i class="icon-pencil"></i> Edit', "class": "btn") }}</td>
             <td width="12%">{{ link_to("profiles/delete/" ~ profile.id, '<i class="icon-remove"></i> Delete', "class": "btn") }}</td>
         </tr>
-    </tbody>
 {% if loop.last %}
-    <tbody>
+    </tbody>
+    <tfoot>
         <tr>
             <td colspan="10" align="right">
                 <div class="btn-group">
@@ -42,7 +42,7 @@
                 </div>
             </td>
         </tr>
-    <tbody>
+    </tfoot>
 </table>
 {% endif %}
 {% else %}

--- a/app/views/users/search.volt
+++ b/app/views/users/search.volt
@@ -23,8 +23,8 @@
             <th>Confirmed?</th>
         </tr>
     </thead>
-{% endif %}
     <tbody>
+{% endif %}
         <tr>
             <td>{{ user.id }}</td>
             <td>{{ user.name }}</td>
@@ -36,9 +36,9 @@
             <td width="12%">{{ link_to("users/edit/" ~ user.id, '<i class="icon-pencil"></i> Edit', "class": "btn") }}</td>
             <td width="12%">{{ link_to("users/delete/" ~ user.id, '<i class="icon-remove"></i> Delete', "class": "btn") }}</td>
         </tr>
-    </tbody>
 {% if loop.last %}
-    <tbody>
+    </tbody>
+    <tfoot>
         <tr>
             <td colspan="10" align="right">
                 <div class="btn-group">
@@ -50,7 +50,7 @@
                 </div>
             </td>
         </tr>
-    <tbody>
+    </tfoot>
 </table>
 {% endif %}
 {% else %}


### PR DESCRIPTION
1 - <tbody> tag in last row (pagination) should have "/" as it's meant to close the element
2 - Used just one tbody containing multiple <tr> for all search result rows, as it is in other tables, like /profiles/edit/1 -> Users tab

3 - This "overwrites" point 1: Changed tbody to tfoot for pagination row as is not really part of the table info. As a consequence it changes background color to white. I have doubts about this point so maybe we can do 1 instead.

