### PR TITLE
Rewrite for profiles/* backend areas for Bootstrap 4.1.1

### DIFF
--- a/app/controllers/ProfilesController.php
+++ b/app/controllers/ProfilesController.php
@@ -99,11 +99,10 @@ class ProfilesController extends ControllerBase
             } else {
                 $this->flash->success("Profile was created successfully");
             }
-
-            Tag::resetInput();
         }
 
         $this->view->form = new ProfilesForm(null);
+        $this->view->form->clear();
     }
 
     /**
@@ -132,13 +131,12 @@ class ProfilesController extends ControllerBase
             } else {
                 $this->flash->success("Profile was updated successfully");
             }
-
-            Tag::resetInput();
         }
 
         $this->view->form = new ProfilesForm($profile, [
             'edit' => true
         ]);
+        $this->view->form->clear();
 
         $this->view->profile = $profile;
     }

--- a/app/forms/ProfilesForm.php
+++ b/app/forms/ProfilesForm.php
@@ -37,24 +37,22 @@ class ProfilesForm extends Form
         } else {
             $id = new Text('id');
         }
-
         $this->add($id);
 
-        $name = new Text('name', [
-            'placeholder' => 'Name'
-        ]);
-
+        $name = new Text('name');
+        $name->setLabel('Name');
         $name->addValidators([
             new PresenceOf([
                 'message' => 'The name is required'
             ])
         ]);
-
         $this->add($name);
 
-        $this->add(new Select('active', [
+        $active = new Select('active', [
             'Y' => 'Yes',
             'N' => 'No'
-        ]));
+        ]);
+        $active->setLabel('Active');
+        $this->add($active);
     }
 }

--- a/app/views/layouts/private.volt
+++ b/app/views/layouts/private.volt
@@ -35,7 +35,7 @@
         <ul class="navbar-nav">
           <li class="nav-item dropdown">
               <a href="#" class="dropdown-toggle nav-link" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" id="drop-menu">{{ auth.getName() }}</a> 
-            <div class="dropdown-menu" aria-lablledby="drop-menu">
+            <div class="dropdown-menu dropdown-menu-right" aria-lablledby="drop-menu">
               {{ link_to('users/changePassword', 'Change Password' , 'class': 'dropdown-item') }}
             </div>
           </li>

--- a/app/views/profiles/create.volt
+++ b/app/views/profiles/create.volt
@@ -1,30 +1,36 @@
-
-<form method="post" autocomplete="off">
-
-<ul class="pager">
-    <li class="previous pull-left">
-        {{ link_to("profiles", "&larr; Go Back") }}
-    </li>
-    <li class="pull-right">
-        {{ submit_button("Save", "class": "btn btn-success") }}
-    </li>
-</ul>
-
 {{ content() }}
 
-<div class="center scaffold">
-    <h2>Create a Profile</h2>
-
-    <div class="clearfix">
-        <label for="name">Name</label>
-        {{ form.render("name") }}
+<div class="row">
+    <div class="col-6">
+        {{ link_to("profiles", '<span class="oi oi-chevron-left" title="chevron-left" aria-hidden="true"></span> Go Back', "class": "btn btn-outline-primary") }}
     </div>
-
-    <div class="clearfix">
-        <label for="active">Active?</label>
-        {{ form.render("active") }}
+    <div class="col-6 text-right">
     </div>
-
 </div>
 
-</form>
+<div class="row d-flex justify-content-center">
+    <div class="col-xl-6  mb-4 mt-4">
+        <h2 class="mb-sm-6 pb-sm-2">Create a Profile</h2>        
+        {{ form("profiles/create", 'role': 'form', 'autocomplete' : 'off') }}
+
+        <div class="form-group row">
+            {{ form.label('name', ['class' : 'col-md-3 col-form-label']) }}    
+            <div class="col-md-9">
+                {{ form.render('name' , ['class' : 'form-control ']) }}
+            </div>
+        </div>
+
+        <div class="form-group row">
+            {{ form.label('active', ['class' : 'col-md-3 col-form-label']) }}    
+            <div class="col-md-9">
+                {{ form.render('active' , ['class' : 'form-control ']) }}
+            </div>
+        </div>
+        <div class="form-group row justify-content-end">
+            <div class="col-md-9" >
+                {{ submit_button("Save", "class": "btn btn-success btn-block") }}
+            </div>
+        </div>
+        </form>    
+    </div>
+</div>

--- a/app/views/profiles/edit.volt
+++ b/app/views/profiles/edit.volt
@@ -1,77 +1,74 @@
+{{ form('role': 'form', 'autocomplete' : 'off') }}
 
-<form method="post" autocomplete="off">
-
-<ul class="pager">
-    <li class="previous pull-left">
-        {{ link_to("profiles", "&larr; Go Back") }}
-    </li>
-    <li class="pull-right">
-        {{ submit_button("Save", "class": "btn btn-success") }}
-    </li>
-</ul>
+<div class="row mb-4">
+    <div class="col-6">
+        {{ link_to("profiles", '<span class="oi oi-chevron-left" title="chevron-left" aria-hidden="true"></span> Go Back', "class": "btn btn-outline-primary") }}
+    </div>
+    <div class="col-6 text-right">
+        {{ submit_button('Save', "class": "btn btn-big btn-success") }}
+    </div>
+</div>    
 
 {{ content() }}
 
-<div class="center scaffold">
+<div class="row d-flex justify-content-center">
+    <div class="col-md-8  mb-4 mt-4">
+        <h2 class="mb-sm-6 pb-sm-2">Edit profile</h2>        
 
-    <h2>Edit profile</h2>
+        <ul class="nav nav-tabs">
+            <li class="nav-item"><a class="nav-link active" role="tab" href="#A" data-toggle="tab">Basic</a></li>
+            <li class="nav-item"><a class="nav-link" href="#B" role="tab" data-toggle="tab">Users</a></li>
+        </ul>
 
-    <ul class="nav nav-tabs">
-        <li class="active"><a href="#A" data-toggle="tab">Basic</a></li>
-        <li><a href="#B" data-toggle="tab">Users</a></li>
-    </ul>
+        <div class="tabbable mt-4">
+            <div class="tab-content">
+                <div class="tab-pane active fade show" role="tabpanel" id="A">
 
-    <div class="tabbable">
-        <div class="tab-content">
-            <div class="tab-pane active" id="A">
+                    {{ form.render("id") }}
 
-                {{ form.render("id") }}
-
-                <div class="clearfix">
-                    <label for="name">Name</label>
-                    {{ form.render("name") }}
+                    <div class="form-group row">
+                        <div class="col-sm-6">
+                            {{ form.label('name') }}    
+                            {{ form.render('name' , ['class' : 'form-control ']) }}
+                        </div>
+                        <div class="col-sm-6">
+                            {{ form.label('active') }}    
+                            {{ form.render('active' , ['class' : 'form-control ']) }}
+                        </div>
+                    </div>
                 </div>
 
-                <div class="clearfix">
-                    <label for="active">Active?</label>
-                    {{ form.render("active") }}
+                <div class="tab-pane fade" role="tabpanel" id="B">
+                    <div class="table-responsive">  
+                        <table class="table table-bordered table-striped text-center">
+                            <thead>
+                                <tr>
+                                    <th>Id</th>
+                                    <th>Name</th>
+                                    <th>Banned?</th>
+                                    <th>Suspended?</th>
+                                    <th>Active?</th>
+                                    <th colspan="2">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for user in profile.users %}
+                                    <tr>
+                                        <td>{{ user.id }}</td>
+                                        <td>{{ user.name }}</td>
+                                        <td>{{ user.banned == 'Y' ? 'Yes' : 'No' }}</td>
+                                        <td>{{ user.suspended == 'Y' ? 'Yes' : 'No' }}</td>
+                                        <td>{{ user.active == 'Y' ? 'Yes' : 'No' }}</td>
+                                        <td width="12%">{{ link_to("users/edit/" ~ user.id, '<span class="oi oi-pencil" title="pencil" aria-hidden="true"></span> Edit', "class": "btn btn-light btn-sm") }}</td>
+                                        <td width="12%">{{ link_to("users/delete/" ~ user.id, '<span class="oi oi-x" title="X" aria-hidden="true"></span> Delete', "class": "btn btn-light btn-sm") }}</td>
+                                    </tr>
+                                {% else %}
+                                    <tr><td colspan="6" align="center">There are no users assigned to this profile</td></tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
-
             </div>
-
-            <div class="tab-pane" id="B">
-                <p>
-                    <table class="table table-bordered table-striped" align="center">
-                        <thead>
-                            <tr>
-                                <th>Id</th>
-                                <th>Name</th>
-                                <th>Banned?</th>
-                                <th>Suspended?</th>
-                                <th>Active?</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        {% for user in profile.users %}
-                            <tr>
-                                <td>{{ user.id }}</td>
-                                <td>{{ user.name }}</td>
-                                <td>{{ user.banned == 'Y' ? 'Yes' : 'No' }}</td>
-                                <td>{{ user.suspended == 'Y' ? 'Yes' : 'No' }}</td>
-                                <td>{{ user.active == 'Y' ? 'Yes' : 'No' }}</td>
-                                <td width="12%">{{ link_to("users/edit/" ~ user.id, '<i class="icon-pencil"></i> Edit', "class": "btn") }}</td>
-                                <td width="12%">{{ link_to("users/delete/" ~ user.id, '<i class="icon-remove"></i> Delete', "class": "btn") }}</td>
-                            </tr>
-                        {% else %}
-                            <tr><td colspan="3" align="center">There are no users assigned to this profile</td></tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </p>
-            </div>
-
         </div>
-    </div>
-
-    </form>
-</div>
+</form>

--- a/app/views/profiles/index.volt
+++ b/app/views/profiles/index.volt
@@ -1,29 +1,36 @@
 {{ content() }}
 
-<div align="right">
-    {{ link_to("profiles/create", "<i class='icon-plus-sign'></i> Create Profiles", "class": "btn btn-primary") }}
+
+<div class="row justify-content-end mb-4">
+    <div class="col-6 text-right">
+    {{ link_to("profiles/create", '<span class="oi oi-plus" title="plus" aria-hidden="true"></span> Create Profile', "class": "btn btn-primary") }}
+    </div>
 </div>
 
-<form method="post" action="{{ url("profiles/search") }}" autocomplete="off">
+    <div class="row d-flex justify-content-center">
+        <div class="col-xl-6  mb-4 mt-4">
+            <h2 class="mb-sm-6 pb-sm-2">Search profiles</h2>        
+            {{ form("profiles/search", 'role': 'form', 'autocomplete' : 'off') }}
+            
+            <div class="form-group row">
+                {{ form.label('id', ['class' : 'col-md-3 col-form-label']) }}    
+                <div class="col-md-9">
+                    {{ form.render('id' , ['class' : 'form-control ']) }}
+                </div>
+            </div>
 
-    <div class="center scaffold">
+            <div class="form-group row">
+                {{ form.label('name', ['class' : 'col-md-3 col-form-label']) }}    
+                <div class="col-md-9">
+                    {{ form.render('name' , ['class' : 'form-control ']) }}
+                </div>
+            </div>
 
-        <h2>Search profiles</h2>
-
-        <div class="clearfix">
-            <label for="id">Id</label>
-            {{ form.render("id") }}
+            <div class="form-group row justify-content-end">
+                <div class="col-md-9" >
+                    {{ submit_button("Search", "class": "btn btn-success btn-block") }}
+                </div>
+            </div>
+            </form>
         </div>
-
-        <div class="clearfix">
-            <label for="name">Name</label>
-            {{ form.render("name") }}
-        </div>
-
-        <div class="clearfix">
-            {{ submit_button("Search", "class": "btn btn-primary") }}
-        </div>
-
     </div>
-
-</form>

--- a/app/views/profiles/search.volt
+++ b/app/views/profiles/search.volt
@@ -1,14 +1,15 @@
 {{ content() }}
 
-<ul class="pager">
-    <li class="previous pull-left">
-        {{ link_to("profiles/index", "&larr; Go Back") }}
-    </li>
-    <li class="pull-right">
-        {{ link_to("profiles/create", "Create profiles", "class": "btn btn-primary") }}
-    </li>
-</ul>
+<div class="row mb-4">
+    <div class="col-6">
+       {{ link_to("profiles/index", '<span class="oi oi-chevron-left" title="chevron-left" aria-hidden="true"></span> Go Back', "class": "btn btn-outline-primary") }}
+    </div>
+    <div class="col-6 text-right">
+        {{ link_to("profiles/create", '<span class="oi oi-plus" title="plus" aria-hidden="true"></span> Create Profile', "class": "btn btn-primary") }}
+    </div>
+</div>
 
+<div class="table-responsive">        
 {% for profile in page.items %}
 {% if loop.first %}
 <table class="table table-bordered table-striped" align="center">
@@ -17,6 +18,7 @@
             <th>Id</th>
             <th>Name</th>
             <th>Active?</th>
+            <th colspan="2">Action</th>
         </tr>
     </thead>
     <tbody>
@@ -25,21 +27,31 @@
             <td>{{ profile.id }}</td>
             <td>{{ profile.name }}</td>
             <td>{{ profile.active == 'Y' ? 'Yes' : 'No' }}</td>
-            <td width="12%">{{ link_to("profiles/edit/" ~ profile.id, '<i class="icon-pencil"></i> Edit', "class": "btn") }}</td>
-            <td width="12%">{{ link_to("profiles/delete/" ~ profile.id, '<i class="icon-remove"></i> Delete', "class": "btn") }}</td>
+            <td width="12%">{{ link_to("profiles/edit/" ~ profile.id, '<span class="oi oi-pencil" title="pencil" aria-hidden="true"></span> Edit', "class": "btn btn-light btn-sm") }}</td>
+            <td width="12%">{{ link_to("profiles/delete/" ~ profile.id, '<span class="oi oi-x" title="X" aria-hidden="true"></span> Delete', "class": "btn btn-light btn-sm") }}</td>
         </tr>
 {% if loop.last %}
     </tbody>
     <tfoot>
         <tr>
-            <td colspan="10" align="right">
-                <div class="btn-group">
-                    {{ link_to("profiles/search", '<i class="icon-fast-backward"></i> First', "class": "btn") }}
-                    {{ link_to("profiles/search?page=" ~ page.before, '<i class="icon-step-backward"></i> Previous', "class": "btn ") }}
-                    {{ link_to("profiles/search?page=" ~ page.next, '<i class="icon-step-forward"></i> Next', "class": "btn") }}
-                    {{ link_to("profiles/search?page=" ~ page.last, '<i class="icon-fast-forward"></i> Last', "class": "btn") }}
-                    <span class="help-inline">{{ page.current }}/{{ page.total_pages }}</span>
-                </div>
+            <td colspan="10" class="text-right"">
+                   <ul class="pagination mb-0">
+                    <li class="page-item">
+                        {{ link_to("profiles/search", '<span class="oi oi-media-skip-backward" title="skip backward" aria-hidden="true"></span> First', "class": "page-link") }}
+                    </li>
+                    <li class="page-item">
+                        {{ link_to("profiles/search?page=" ~ page.before, '<span class="oi oi-media-step-backward" title="step backward" aria-hidden="true"></span> Previous', "class": "page-link") }}
+                    </li>
+                    <li class="page-item disabled">
+                        {{ link_to("#", page.current ~ "/" ~ page.total_pages, "class":"page-link") }}
+                    </li>
+                    <li class="page-item">
+                        {{ link_to("profiles/search?page=" ~ page.next, '<span class="oi oi-media-step-forward" title="step forward" aria-hidden="true"></span> Next', "class": "page-link") }}
+                    </li>
+                    <li class="page-item">
+                        {{ link_to("profiles/search?page=" ~ page.last, '<span class="oi oi-media-skip-forward" title="skip forward" aria-hidden="true"></span> Last', "class": "page-link") }}
+                    </li>
+                </ul>
             </td>
         </tr>
     </tfoot>
@@ -48,3 +60,4 @@
 {% else %}
     No profiles are recorded
 {% endfor %}
+</div>


### PR DESCRIPTION
Continuing with Bootstrap 4.1.1 update for Vokuro, this one is rewrite for profiles/edit, profiles/create, profiles/index , profiles/search for BS4.1.1. Changes includes: 
 * Added some label in Phalcon Form declaration so that can render using VOLT in views
 * Removed deprecated Tag::resetInput() from ProfilesController.php replaced with appropriate $formObject->clear()
 * Used VOLT form instead of html <form> 
 * Small CSS fix in private.volt dropdown menu

More updates on the way.. 

Refs: https://github.com/phalcon/vokuro/issues/58