### PR TITLE
add assets provider and move static resources there

### DIFF
--- a/config/providers.php
+++ b/config/providers.php
@@ -26,6 +26,7 @@ use Vokuro\Providers\SessionBagProvider;
 use Vokuro\Providers\SessionProvider;
 use Vokuro\Providers\UrlProvider;
 use Vokuro\Providers\ViewProvider;
+use Vokuro\Providers\AssetsProvider;
 
 return [
     AclProvider::class,
@@ -44,4 +45,6 @@ return [
     SecurityProvider::class,
     UrlProvider::class,
     ViewProvider::class,
+    ViewProvider::class,
+    AssetsProvider::class,
 ];

--- a/config/providers.php
+++ b/config/providers.php
@@ -45,6 +45,5 @@ return [
     SecurityProvider::class,
     UrlProvider::class,
     ViewProvider::class,
-    ViewProvider::class,
     AssetsProvider::class,
 ];

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1,7 +1,7 @@
-;var Admin = (function () {
-    'use strict';
+var Admin = (function () {
+    "use strict";
 
-    var $adminDemoContainer = "";
+    var $adminDemoContainer;
 
     function setVars() {
         $adminDemoContainer = $("#adminDemoContainer");
@@ -9,7 +9,8 @@
 
     function getRandomColor() {
 
-        return '#'+Math.floor(Math.random()*16777215).toString(16);
+        return "#"+"0123456789abcdef".split("").map(function(v,i,a){
+            return i>5 ? null : a[Math.floor(Math.random()*16)] }).join("");
     }
 
     function initAdminPrivateDemo() {
@@ -39,8 +40,9 @@
                 me.init();
             }
         );
-    }
+    };
 })();
 
 //init the javascript "class"
-new Admin();
+var Admin = new Admin();
+

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -10,7 +10,7 @@ var Admin = (function () {
     function getRandomColor() {
 
         return "#" + "0123456789abcdef".split("").map(function (v, i, a) {
-            return i > 5 ? null : a[Math.floor(Math.random() * 16)]
+            return i > 5 ? null : a[Math.floor(Math.random() * 16)];
         }).join("");
     }
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1,0 +1,46 @@
+;var Admin = (function () {
+    'use strict';
+
+    var $adminDemoContainer = "";
+
+    function setVars() {
+        $adminDemoContainer = $("#adminDemoContainer");
+    }
+
+    function getRandomColor() {
+
+        return '#'+Math.floor(Math.random()*16777215).toString(16);
+    }
+
+    function initAdminPrivateDemo() {
+
+        if ( $adminDemoContainer.length === 0 ) {
+            return;
+        }
+
+        setInterval(function () {
+            $adminDemoContainer.css({
+                "color" : getRandomColor(),
+            });
+        }, 2000);
+    }
+
+    return function () {
+
+        var me = this;
+
+        this.init = function () {
+            setVars();
+            initAdminPrivateDemo();
+        };
+
+        $(document).ready(
+            function () {
+                me.init();
+            }
+        );
+    }
+})();
+
+//init the javascript "class"
+new Admin();

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -9,8 +9,9 @@ var Admin = (function () {
 
     function getRandomColor() {
 
-        return "#"+"0123456789abcdef".split("").map(function(v,i,a){
-            return i>5 ? null : a[Math.floor(Math.random()*16)] }).join("");
+        return "#" + "0123456789abcdef".split("").map(function (v, i, a) {
+            return i > 5 ? null : a[Math.floor(Math.random() * 16)]
+        }).join("");
     }
 
     function initAdminPrivateDemo() {
@@ -21,7 +22,7 @@ var Admin = (function () {
 
         setInterval(function () {
             $adminDemoContainer.css({
-                "color" : getRandomColor(),
+                "color": getRandomColor(),
             });
         }, 2000);
     }
@@ -41,8 +42,9 @@ var Admin = (function () {
             }
         );
     };
-})();
+}());
 
-//init the javascript "class"
-var Admin = new Admin();
-
+if ( typeof vokuro === "undefined" ) {
+    vokuro = {};
+}
+vokuro.admin = new Admin();

--- a/src/Controllers/UsersController.php
+++ b/src/Controllers/UsersController.php
@@ -28,6 +28,7 @@ class UsersController extends ControllerBase
     public function initialize(): void
     {
         $this->view->setTemplateBefore('private');
+        $this->assets->collection("js")->addJs("/js/admin.js", true, true);
     }
 
     /**

--- a/src/Providers/AssetsProvider.php
+++ b/src/Providers/AssetsProvider.php
@@ -38,26 +38,34 @@ class AssetsProvider implements ServiceProviderInterface
         $di->setShared($this->providerName, function () use ($assetManager) {
 
             $assetManager->collection('css')
-                ->addCss('//stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css?dc=' . self::VERSION,
-                    false, false, [
+                ->addCss(
+                    '//stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css?dc=' . self::VERSION,
+                    false,
+                    false,
+                    [
                         "media"       => "screen,projection",
                         "integrity"   => "sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T",
                         "crossorigin" => "anonymous"
-                    ])
+                    ]
+                )
                 ->addCss('/css/style.css', true, true, [
                     "media" => "screen,projection"
                 ]);
 
             $assetManager->collection('js')
                 ->addJs('//code.jquery.com/jquery-3.3.1.slim.min.js?dc=' . self::VERSION, false, true, [
-                    "integrity" => "sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo",
+                    "integrity"   => "sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo",
                     "crossorigin" => "anonymous"
                 ])
-                ->addJs('//stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js?dc=' . self::VERSION,
-                    false, true, [
-                        "integrity" => "sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM",
+                ->addJs(
+                    '//stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js?dc=' . self::VERSION,
+                    false,
+                    true,
+                    [
+                        "integrity"   => "sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM",
                         "crossorigin" => "anonymous"
-                    ]);
+                    ]
+                );
 
             return $assetManager;
         });

--- a/src/Providers/AssetsProvider.php
+++ b/src/Providers/AssetsProvider.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Vökuró.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Vokuro\Providers;
+
+use Phalcon\Di\DiInterface;
+use Phalcon\Di\ServiceProviderInterface;
+use Phalcon\Assets\Manager;
+
+class AssetsProvider implements ServiceProviderInterface
+{
+
+    protected const VERSION = "1.0.0";
+    /**
+     * @var string
+     */
+    protected $providerName = 'assets';
+
+    /**
+     * @param DiInterface $di
+     *
+     * @return void
+     */
+    public function register(DiInterface $di): void
+    {
+
+        $assetManager = new Manager();
+
+        $di->setShared($this->providerName, function () use ($assetManager) {
+
+            $assetManager->collection('css')
+                ->addCss('//stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css?dc=' . self::VERSION,
+                    false, false, [
+                        "media"       => "screen,projection",
+                        "integrity"   => "sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T",
+                        "crossorigin" => "anonymous"
+                    ])
+                ->addCss('/css/style.css', true, true, [
+                    "media" => "screen,projection"
+                ]);
+
+            $assetManager->collection('js')
+                ->addJs('//code.jquery.com/jquery-3.3.1.slim.min.js?dc=' . self::VERSION, false, true, [
+                    "integrity" => "sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo",
+                    "crossorigin" => "anonymous"
+                ])
+                ->addJs('//stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js?dc=' . self::VERSION,
+                    false, true, [
+                        "integrity" => "sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM",
+                        "crossorigin" => "anonymous"
+                    ]);
+
+            return $assetManager;
+        });
+    }
+}

--- a/src/Providers/AssetsProvider.php
+++ b/src/Providers/AssetsProvider.php
@@ -18,7 +18,6 @@ use Phalcon\Assets\Manager;
 
 class AssetsProvider implements ServiceProviderInterface
 {
-
     protected const VERSION = "1.0.0";
     /**
      * @var string
@@ -32,7 +31,6 @@ class AssetsProvider implements ServiceProviderInterface
      */
     public function register(DiInterface $di): void
     {
-
         $assetManager = new Manager();
 
         $di->setShared($this->providerName, function () use ($assetManager) {

--- a/tests/unit/providers/AssetsProviderTest.php
+++ b/tests/unit/providers/AssetsProviderTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Vokuro\Tests\Unit\Providers;
+
+use Codeception\Test\Unit;
+use Phalcon\Assets\Manager as AssetsManager;
+use Vokuro\Providers\AssetsProvider;
+
+final class AssetsProviderTest extends Unit
+{
+    public function testConstruct(): void
+    {
+        $class = $this->make(AssetsProvider::class);
+
+        $this->assertInstanceOf(AssetsManager::class, $class);
+    }
+}

--- a/tests/unit/providers/AssetsProviderTest.php
+++ b/tests/unit/providers/AssetsProviderTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Vokuro\Tests\Unit\Providers;
 
 use Codeception\Test\Unit;
-use Phalcon\Assets\Manager as AssetsManager;
+use Phalcon\Di\ServiceProviderInterface;
 use Vokuro\Providers\AssetsProvider;
 
 final class AssetsProviderTest extends Unit
@@ -13,6 +13,6 @@ final class AssetsProviderTest extends Unit
     {
         $class = $this->make(AssetsProvider::class);
 
-        $this->assertInstanceOf(AssetsManager::class, $class);
+        $this->assertInstanceOf(ServiceProviderInterface::class, $class);
     }
 }

--- a/themes/vokuro/index.volt
+++ b/themes/vokuro/index.volt
@@ -1,24 +1,14 @@
+{% set DI = this.getDi() %}
 <!DOCTYPE html>
 <html lang="en" class="h-100">
 <head>
     <title>Welcome to Vökuró</title>
 
-    <link rel="stylesheet"
-          href="//stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-          integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
-          crossorigin="anonymous">
-
-    {{ stylesheet_link('css/style.css') }}
+    {{ assets.outputCss('css') }}
 </head>
 <body class="d-flex flex-column h-100">
     {{ content() }}
 
-    <script src="//code.jquery.com/jquery-3.3.1.slim.min.js"
-            integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
-            crossorigin="anonymous"></script>
-
-    <script src="//stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
-            integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
-            crossorigin="anonymous"></script>
+    {{ assets.outputJs('js') }}
 </body>
 </html>

--- a/themes/vokuro/index.volt
+++ b/themes/vokuro/index.volt
@@ -1,4 +1,3 @@
-{% set DI = this.getDi() %}
 <!DOCTYPE html>
 <html lang="en" class="h-100">
 <head>

--- a/themes/vokuro/users/index.volt
+++ b/themes/vokuro/users/index.volt
@@ -3,6 +3,7 @@
 <div class="mb-5">
     {{ link_to("users/create", "Create Users", "class": "btn btn-primary") }}
 </div>
+<h6 id="adminDemoContainer">Seperated admin javascript has been loaded to private/admin layout</h6>
 
 <form class="form-inline" method="get" action="{{ url("users/search") }}">
     <div class="form-group">


### PR DESCRIPTION
Hello,

This patch takes advantage of Phalcon's asset manager.
I replaced the current assets loaded in the public layout and put them in a new assets provider.

Also, I added a sample admin javascript file to illustrate the potential usage of the assets provider. 

The message isn't what you call beautiful, but for me, the idea of the admin area is to be implemented by people to suits their needs. 

