### PR TITLE
AssesManager change context form admin to privateUsers

### DIFF
--- a/public/js/privateUsers.js
+++ b/public/js/privateUsers.js
@@ -1,10 +1,10 @@
-var Admin = (function () {
+var PrivateUsers = (function () {
     "use strict";
 
-    var $adminDemoContainer;
+    var $blinkTextContainer;
 
     function setVars() {
-        $adminDemoContainer = $("#adminDemoContainer");
+        $blinkTextContainer = $("#usersAssetManagerDemoTextContainer");
     }
 
     function getRandomColor() {
@@ -14,14 +14,14 @@ var Admin = (function () {
         }).join("");
     }
 
-    function initAdminPrivateDemo() {
+    function initUsersBlinkingTextDemo() {
 
-        if ( $adminDemoContainer.length === 0 ) {
+        if ( $blinkTextContainer.length === 0 ) {
             return;
         }
 
         setInterval(function () {
-            $adminDemoContainer.css({
+            $blinkTextContainer.css({
                 "color": getRandomColor(),
             });
         }, 2000);
@@ -33,7 +33,7 @@ var Admin = (function () {
 
         this.init = function () {
             setVars();
-            initAdminPrivateDemo();
+            initUsersBlinkingTextDemo();
         };
 
         $(document).ready(
@@ -47,4 +47,4 @@ var Admin = (function () {
 if ( typeof vokuro === "undefined" ) {
     vokuro = {};
 }
-vokuro.admin = new Admin();
+vokuro.privateUsers = new PrivateUsers();

--- a/src/Controllers/UsersController.php
+++ b/src/Controllers/UsersController.php
@@ -28,7 +28,6 @@ class UsersController extends ControllerBase
     public function initialize(): void
     {
         $this->view->setTemplateBefore('private');
-        $this->assets->collection("js")->addJs("/js/admin.js", true, true);
     }
 
     /**
@@ -37,6 +36,7 @@ class UsersController extends ControllerBase
     public function indexAction(): void
     {
         $this->view->setVar('form', new UsersForm());
+        $this->assets->collection("js")->addJs("/js/privateUsers.js", true, true);
     }
 
     /**

--- a/src/Providers/AssetsProvider.php
+++ b/src/Providers/AssetsProvider.php
@@ -46,7 +46,7 @@ class AssetsProvider implements ServiceProviderInterface
                         "crossorigin" => "anonymous"
                     ]
                 )
-                ->addCss('/css/style.css', true, true, [
+                ->addCss('/css/style.css?dc=' . self::VERSION, true, true, [
                     "media" => "screen,projection"
                 ]);
 

--- a/themes/vokuro/users/index.volt
+++ b/themes/vokuro/users/index.volt
@@ -3,7 +3,7 @@
 <div class="mb-5">
     {{ link_to("users/create", "Create Users", "class": "btn btn-primary") }}
 </div>
-<h6 id="adminDemoContainer">Seperated admin javascript has been loaded to private/admin layout</h6>
+<h6 id="usersAssetManagerDemoTextContainer">Separated javascript has been loaded</h6>
 
 <form class="form-inline" method="get" action="{{ url("users/search") }}">
     <div class="form-group">


### PR DESCRIPTION
Hi,

as we spoke, ditch the `admin` in favor of `private` for assetManager usage.

also fixed a forgoten "don't cache" param for style.css 