### PR TITLE
Fix  Serialization of 'Closure' is not allowed

### DIFF
--- a/src/Controllers/ProfilesController.php
+++ b/src/Controllers/ProfilesController.php
@@ -48,7 +48,9 @@ class ProfilesController extends ControllerBase
     {
         if ($this->request->isPost()) {
             $query = Criteria::fromInput($this->di, Profiles::class, $this->request->getPost());
-            $this->persistent->searchParams = $query->getParams();
+            $searchparams=$query->getParams(); 
+            unset($searchparams["di"]);
+            $this->persistent->searchParams=$searchparams;
         }
 
         $parameters = [];

--- a/src/Controllers/ProfilesController.php
+++ b/src/Controllers/ProfilesController.php
@@ -49,7 +49,7 @@ class ProfilesController extends ControllerBase
         if ($this->request->isPost()) {
             $query = Criteria::fromInput($this->di, Profiles::class, $this->request->getPost());
             $searchparams = $query->getParams(); 
-            unset($searchparams["di"]);
+            unset($searchparams['di']);
             $this->persistent->searchParams = $searchparams;
         }
 

--- a/src/Controllers/ProfilesController.php
+++ b/src/Controllers/ProfilesController.php
@@ -50,7 +50,7 @@ class ProfilesController extends ControllerBase
             $query = Criteria::fromInput($this->di, Profiles::class, $this->request->getPost());
             $searchparams=$query->getParams(); 
             unset($searchparams["di"]);
-            $this->persistent->searchParams=$searchparams;
+            $this->persistent->searchParams = $searchparams;
         }
 
         $parameters = [];

--- a/src/Controllers/ProfilesController.php
+++ b/src/Controllers/ProfilesController.php
@@ -48,7 +48,7 @@ class ProfilesController extends ControllerBase
     {
         if ($this->request->isPost()) {
             $query = Criteria::fromInput($this->di, Profiles::class, $this->request->getPost());
-            $searchparams=$query->getParams(); 
+            $searchparams = $query->getParams(); 
             unset($searchparams["di"]);
             $this->persistent->searchParams = $searchparams;
         }


### PR DESCRIPTION
This will fix  the error  -- message Serialization of 'Closure' is not allowed in [no active file] on line 0 -- , this appears when you press click on the search button in the profile page. this happends to me on windows 8.1 and centos 6.10