### PR TITLE
upgraded to phalcon 4.0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,13 @@
         "vlucas/phpdotenv": "^3.6"
     },
     "require-dev": {
-        "codeception/codeception": "^3.1",
-        "phalcon/ide-stubs": "4.0.0",
+        "codeception/codeception": "^4.1.6",
+        "phalcon/ide-stubs": "4.0.6",
         "phpunit/phpunit": "^8.4",
-        "squizlabs/php_codesniffer": "3.5",
-        "vimeo/psalm": "^3.7"
+        "squizlabs/php_codesniffer": "3.5.5",
+        "vimeo/psalm": "^3.7",
+        "codeception/module-phpbrowser": "^1.0",
+        "codeception/module-asserts": "^1.2"
     },
     "suggest": {
         "ext-apc": "Needed to support caching ACL"


### PR DESCRIPTION
Hey Phalcon-Team, 

I just tested this against codeception test with current environment (PHP 7.4.6 + Phalcon 4.0.6) -> all tests passed.

See forum for more information -> https://forum.phalcon.io/discussion/20727/using-vokuro-hint-of-composer-that-facebookwebdriver-is-abandone

Greets,
Marco